### PR TITLE
chore(npmrc): add `.npmrc` to only allow yarn or npm to install npm packages with exact versions

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+save-exact=true


### PR DESCRIPTION
Close: #3 